### PR TITLE
Adds more support for job transitions

### DIFF
--- a/esgfpub/scripts/timerect/fix_time.py
+++ b/esgfpub/scripts/timerect/fix_time.py
@@ -11,7 +11,8 @@ def fix_units(inpath, outpath, time_units, offset):
     with xr.open_dataset(inpath, decode_times=False) as ds:
         if ds.get('time') is None:
             raise ValueError(f"{inpath} has no 'time' axis")
-        bnds_name = 'time_bnds' if ds.get('time_bnds') is not None else 'time_bounds'
+        bnds_name = 'time_bnds' if ds.get(
+            'time_bnds') is not None else 'time_bounds'
         if ds['time'].attrs.get('units') != time_units:
             ds = ds.assign_coords(time=ds['time']+offset)
             if bnds_name == 'time_bnds':
@@ -34,7 +35,7 @@ def fix_units(inpath, outpath, time_units, offset):
             }
             ds.to_netcdf(outpath, unlimited_dims=['time'])
 
-4
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/warehouse/listener.py
+++ b/warehouse/listener.py
@@ -35,7 +35,6 @@ class Listener(object):
         print(f"{event.src_path} has been created")
 
     def on_modified(self, event):
-        print(f"{event.src_path} has been modified")
         with open(event.src_path, 'r') as instream:
             lines = [line for line in instream.readlines() if 'STAT' in line]
         if 'Engaged' not in lines[-1]:

--- a/warehouse/scripts/check_identical.py
+++ b/warehouse/scripts/check_identical.py
@@ -1,0 +1,69 @@
+import sys
+import os
+import argparse
+from tqdm import tqdm
+from pathlib import Path
+from math import isclose
+from numpy import allclose, subtract, not_equal, array_equal, where
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Check that the contents of two files are identical")
+    parser.add_argument('file_one', type=str,
+                        help="Path a netCDF files")
+    parser.add_argument('file_two', type=str,
+                        help="Path a netCDF files")
+    parser.add_argument('--var-list', nargs="*",
+                        default=["all"],
+                        help="Variables to check, default is all")
+    parser.add_argument('--exclude', nargs="*",
+                        default=["lat", "lon", "area", "hyam", "hybm",
+                                 "hyai", "hybi", "date_written", "time_written"],
+                        help="Variables to check, default is all")
+    return parser.parse_args()
+
+
+def main():
+    parsed_args = parse_args()
+    import xarray as xr
+
+    file_one = Path(parsed_args.file_one)
+    file_two = Path(parsed_args.file_two)
+    vars_to_check = parsed_args.var_list
+
+    if not file_one.exists() or not file_two.exists():
+        raise ValueError("One of more input files does not exist")
+
+    data1 = xr.open_dataset(str(file_one.resolve()))
+    data2 = xr.open_dataset(str(file_two.resolve()))
+
+    all_match = True
+    dont_match = []
+    for variable in tqdm(data1.data_vars):
+
+        if ("all" not in vars_to_check and variable not in vars_to_check) \
+        or "bnds" in variable \
+        or variable in parsed_args.exclude:
+            continue
+
+        a = data1[variable].load().values
+        b = data2[variable].load().values
+        if not allclose(a, b, equal_nan=True):
+            dont_match.append(f"Values do not match for {variable}")
+            all_match = False
+
+    data1.close()
+    data2.close()
+
+    if all_match:
+        print("All variables match")
+        return 0
+
+    for m in dont_match:
+        print(m)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/warehouse/scripts/check_time_units.py
+++ b/warehouse/scripts/check_time_units.py
@@ -1,8 +1,13 @@
 import sys
+import os
 import argparse
 import xarray as xr
 from tqdm import tqdm
 from pathlib import Path
+from concurrent.futures import ProcessPoolExecutor, as_completed
+import operator
+
+from dataclasses import dataclass
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -13,38 +18,58 @@ def parse_args():
                         help="The name of the time axis, default is 'time'")
     parser.add_argument('-q', '--quiet', action="store_true",
                         help="suppress status bars and console output")
+    parser.add_argument('-p', '--processes', type=int, default=8,
+                        help="number of parallel processes")
     return parser.parse_args()
 
 
-def check_file(filepath, timename):
+def check_file(idx, filepath, timename):
     """
     Return the time units from the file at the path
     """
     with xr.open_dataset(filepath, decode_times=False) as ds:
         # will return None if there aren't any units
-        return ds[timename].attrs.get('units')
+        return idx, ds[timename].attrs.get('units')
 
+@dataclass
+class FileItem:
+    units: str
+    path: str
 
 def main():
     parsed_args = parse_args()
-    units = []
-    if not parsed_args.quiet:
-        total = 0
-        for _ in Path(parsed_args.input).glob('*.nc'):
-            total += 1
-    else:
-        total = None
+    
+    futures = []
+    files = sorted([
+        FileItem(units=None, path=str(x.resolve()))
+        for x in Path(parsed_args.input).glob('*.nc')],
+        key=operator.attrgetter('path'))
 
-    pbar = tqdm(Path(parsed_args.input).glob('*.nc'), disable=parsed_args.quiet, total=total)
-    for item in pbar:
-        if not item.exists():
-            continue
-        if not parsed_args.quiet:
-            desc = f"Checking {item.name}"
-            pbar.set_description(desc)
-        units.append(check_file(item.resolve(), parsed_args.time_name))
-    for unit in units:
-        if unit != units[0]:
+    with ProcessPoolExecutor(max_workers=parsed_args.processes) as pool:
+        for idx, item in enumerate(files):
+            futures.append(
+                pool.submit(
+                    check_file, idx, item.path, parsed_args.time_name))
+
+        pbar = tqdm(disable=parsed_args.quiet, total=len(files))
+        for future in as_completed(futures):
+            pbar.update(1)
+            idx, units = future.result()
+            files[idx].units = units
+        pbar.close()
+
+    expected_units = files[0].units
+    for idx, info in enumerate(files):
+        if expected_units != files[idx].units:
+            with xr.open_dataset(files[idx-1].path, decode_times=False) as ds:
+                freq = ds['time_bnds'].values[0][1] - ds['time_bnds'].values[0][0]
+                offset = ds['time'].values[-1] + freq
+            message = f"correct_units={expected_units},offset={offset}"
+            if (messages_path := os.environ.get('MESSAGES_FILE')):
+                with open(messages_path, 'w') as outstream:
+                    outstream.write(message.replace(':', '^'))
+            else:
+                print(message)
             return 1
     return 0
 

--- a/warehouse/scripts/check_time_units.py
+++ b/warehouse/scripts/check_time_units.py
@@ -65,7 +65,7 @@ def main():
                 freq = ds['time_bnds'].values[0][1] - ds['time_bnds'].values[0][0]
                 offset = ds['time'].values[-1] + freq
             message = f"correct_units={expected_units},offset={offset}"
-            if (messages_path := os.environ.get('MESSAGES_FILE')):
+            if (messages_path := os.environ.get('message_file')):
                 with open(messages_path, 'w') as outstream:
                     outstream.write(message.replace(':', '^'))
             else:

--- a/warehouse/scripts/fix_time_units.py
+++ b/warehouse/scripts/fix_time_units.py
@@ -1,65 +1,92 @@
 import os
+from sys import exit
 import argparse
 from tqdm import tqdm
-import xarray as xr
-from subprocess import Popen, PIPE
+from pathlib import Path
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('input', 
-                        help="path to directory containing data with incorrect time units")
-    parser.add_argument('output', 
-                        help="path to directory where corrected data should be saved")
-    parser.add_argument('--bounds-name', 
-                        type=str, default="time_bnds")
-    parser.add_argument('--time-units',
-                        default="days since 1850-01-01 00:00:00")
-    parser.add_argument('--processes', 
-                        default=6, type=int)
-    parser.add_argument('--quiet', 
-                        action="store_true", help="Suppress progressbars")
-    return parser.parse_args()
-
-
-def fix_units(inpath, outpath, time_units, bounds_name):
-
+def fix_units(inpath, outpath, time_units, offset):
+    import xarray as xr
     with xr.open_dataset(inpath, decode_times=False) as ds:
+        if ds.get('time') is None:
+            raise ValueError(f"{inpath} has no 'time' axis")
+        bnds_name = 'time_bnds' if ds.get(
+            'time_bnds') is not None else 'time_bounds'
         if ds['time'].attrs.get('units') != time_units:
+            ds = ds.assign_coords(time=ds['time']+offset)
+            if bnds_name == 'time_bnds':
+                ds = ds.assign_coords(time_bnds=ds[bnds_name]+offset)
+            else:
+                ds = ds.assign_coords(time_bounds=ds[bnds_name]+offset)
+            if ds[bnds_name].values[0][0] == ds[bnds_name].values[0][1]:
+                freq = ds[bnds_name].values[1][1] - ds[bnds_name].values[1][0]
+                ds[bnds_name].values[0][0] -= freq
             ds['time'].attrs = {
                 'long_name': "time",
                 'units': time_units,
                 'calendar': "noleap",
-                'bounds': bounds_name }
+                'bounds': bnds_name
+            }
+            ds['time_bnds'].attrs = {
+                "long_name": "time interval endpoints"
+            }
             ds.to_netcdf(outpath, unlimited_dims=['time'])
+        else:
+            os.symlink(inpath, outpath)
 
 
 def main():
-    
-    parsed_args = parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'input',
+        help="path to directory containing data with incorrect time units")
+    parser.add_argument(
+        'output',
+        help="path to directory where corrected data should be saved")
+    parser.add_argument(
+        '-t', '--time-offset',
+        type=float, default=0.0,
+        help="Value to increase time and time_bnds index by")
+    parser.add_argument(
+        '-d', '--time-units',
+        default="days since 1850-01-01 00:00:00")
+    parser.add_argument(
+        '-p', '--processes',
+        default=6, type=int,
+        help="Number of parallel processes")
+    parser.add_argument(
+        '-q', '--quiet',
+        action="store_true",
+        help="Suppress progress bars")
+    args = parser.parse_args()
+    os.makedirs(args.output, exist_ok=True)
 
-    os.makedirs(parsed_args.output, exist_ok=True)
-
-    with ProcessPoolExecutor(max_workers=parsed_args.processes) as pool:
-
-        files = os.listdir(parsed_args.input)
+    total = 0
+    for _ in Path(args.input).glob('*'):
+        total += 1 
+    with ProcessPoolExecutor(max_workers=args.processes) as pool:
         futures = []
-
-        for f in files:
-            inpath = os.path.join(parsed_args.input, f)
-            outpath = os.path.join(parsed_args.output, f)
-            futures.append(
-                pool.submit(
-                    fix_units,
+        for path in Path(args.input).glob('*'):
+            inpath = str(path.resolve())
+            outpath = str(Path(args.output, path.name).resolve())
+            if args.processes > 1:
+                futures.append(
+                    pool.submit(
+                        fix_units,
+                        inpath,
+                        outpath,
+                        args.time_units,
+                        args.time_offset))
+            else:
+                fix_units(
                     inpath,
                     outpath,
-                    parsed_args.time_units,
-                    parsed_args.time_offset))
-
-        for _ in tqdm(as_completed(futures), total=len(files), disable=parsed_args.quiet):
-            pass
-
+                    args.time_units,
+                    args.time_offset)
+        if args.processes > 1:
+            for _ in tqdm(as_completed(futures), total=total, disable=args.quiet):
+                pass
     return 0
 
 

--- a/warehouse/workflows/__init__.py
+++ b/warehouse/workflows/__init__.py
@@ -45,7 +45,7 @@ class Workflow(object):
         else:
             return prefix
 
-    def next_state(self, dataset, status, idx=0):
+    def next_state(self, dataset, state, params, idx=0):
         """
         Parameters: 
             dataset (Dataset) : The dataset which is changing state
@@ -53,45 +53,47 @@ class Workflow(object):
             idx (int) : The recursive depth index
         Returns the name of the next state to transition to given the current state of the dataset
         """
-
-        status_attrs = status.split(':')
-        if len(status_attrs) < 3:
-            target_state = status
+        state_attrs = state.split(':')
+        if len(state_attrs) < 3:
+            target_state = state
         else:
-            target_state = f"{status_attrs[-3]}:{status_attrs[-2]}"
+            target_state = f"{state_attrs[-3]}:{state_attrs[-2]}"
         prefix = self.get_status_prefix()
         if target_state in self.transitions.keys():
             target_data_type = f'{dataset.realm}-{dataset.grid}-{dataset.freq}'
             transitions = self.transitions[target_state].get(target_data_type)
             if transitions is None:
-                return [(x, self) for x in self.transitions[target_state]['default']]
+                return [(f'{prefix}{x}:', self, params) for x in self.transitions[target_state]['default']]
             else:
-                return [(f'{prefix}{t}:', self) for t in transitions]
+                return [(f'{prefix}{x}:', self, params) for x in transitions]
             
-        elif status_attrs[idx] == "WAREHOUSE":
-            return self.next_state(dataset, status, idx + 1)
+        elif state_attrs[idx] == "WAREHOUSE":
+            return self.next_state(dataset, state, params, idx + 1)
 
-        elif status_attrs[idx] in self.children.keys():
-            return self.children[status_attrs[idx]].next_state(dataset, status, idx + 1)
+        elif state_attrs[idx] in self.children.keys():
+            return self.children[state_attrs[idx]].next_state(dataset, state, params, idx + 1)
 
         else:
-            if "Exit:Success" in target_state:
-                dataset.update_status(f'{prefix}Pass:')
-                return None
-            elif "Exit:Fail" in target_state:
-                dataset.update_status(f'{prefix}Fail:')
-                return None
-            else:
-                raise ValueError(
-                    f"{target_state} is not present in the transition graph for {self.name}")
+            raise ValueError(
+                f"{target_state} is not present in the transition graph for {self.name}")
 
-    def get_job(self, dataset, state, scripts_path, slurm_out_path, workflow, **kwargs):
+    def get_job(self, dataset, state, params, scripts_path, slurm_out_path, workflow, job_workers=8, **kwargs):
 
-        job = self.jobs[state]
+        state_attrs = state.split(':')
+        job_name = state_attrs[-3]
+
+        parent = f"{state_attrs[0]}:{state_attrs[1]}"
+    
+        job = self.jobs[job_name]
         job_instance = job(
-            dataset, state, scripts_path, slurm_out_path, 
+            dataset, 
+            state, 
+            scripts_path, 
+            slurm_out_path,
+            params=params,
             slurm_opts=kwargs.get('slurm_opts', []), 
-            parent=workflow.get_status_prefix())
+            parent=parent,
+            job_workers=job_workers)
         job_instance.setup_requisites()
         return job_instance
         

--- a/warehouse/workflows/extraction/transitions.yaml
+++ b/warehouse/workflows/extraction/transitions.yaml
@@ -7,14 +7,14 @@ ZstashExtract:Ready:
         -  ExtractionValidate:Ready
 ZstashExtract:Fail:
     default:
-        -  Exit:exit_code
+        -  Fail
 
 ExtractionValidate:Ready:
     default:
         -  ExtractionValidate:Engaged
 ExtractionValidate:Pass:
     default:
-        -  Exit:Success
+        -  Pass
 ExtractionValidate:Fail:
     default:
-        -  Exit:exit_code
+        -  Fail

--- a/warehouse/workflows/jobs/__init__.py
+++ b/warehouse/workflows/jobs/__init__.py
@@ -41,9 +41,9 @@ class WorkflowJob(object):
 
         script_name = f'{self._dataset.experiment}-{self.name}-{self._dataset.realm}-{self._dataset.grid}-{self._dataset.freq}'
         tmp = NamedTemporaryFile(dir=self._slurm_out, delete=False, prefix=script_name)
-        messages_file = NamedTemporaryFile(dir=self._slurm_out, delete=False)
-        Path(messages_file.name).touch()
-        self._cmd = f"export MESSAGES_FILE={messages_file.name}\n" + self._cmd
+        message_file = NamedTemporaryFile(dir=self._slurm_out, delete=False)
+        Path(message_file.name).touch()
+        self._cmd = f"export message_file={message_file.name}\n" + self._cmd
 
         self.add_cmd_suffix(working_dir)
         slurm.render_script(self.cmd, tmp.name, self._slurm_opts)
@@ -56,12 +56,12 @@ class WorkflowJob(object):
         suffix = f"""
 if [ $? -ne 0 ]
 then 
-    echo STAT:`date +%Y%m%d_%H%M%S`:WAREHOUSE:{self.parent}:{self.name}:Fail:`cat $MESSAGES_FILE` >> {self.dataset.status_path}
+    echo STAT:`date +%Y%m%d_%H%M%S`:WAREHOUSE:{self.parent}:{self.name}:Fail:`cat $message_file` >> {self.dataset.status_path}
 else
-    echo STAT:`date +%Y%m%d_%H%M%S`:WAREHOUSE:{self.parent}:{self.name}:Pass:`cat $MESSAGES_FILE` >> {self.dataset.status_path}
+    echo STAT:`date +%Y%m%d_%H%M%S`:WAREHOUSE:{self.parent}:{self.name}:Pass:`cat $message_file` >> {self.dataset.status_path}
 fi
 rm {Path(working_dir, ".lock")}
-rm $MESSAGES_FILE
+rm $message_file
 """
         self._cmd = self._cmd + suffix
 

--- a/warehouse/workflows/jobs/__init__.py
+++ b/warehouse/workflows/jobs/__init__.py
@@ -4,7 +4,7 @@ from tempfile import NamedTemporaryFile
 
 class WorkflowJob(object):
 
-    def __init__(self, dataset, state, scripts_path, slurm_out_path, slurm_opts=[], **kwargs):
+    def __init__(self, dataset, state, scripts_path, slurm_out_path, slurm_opts=[], params={}, **kwargs):
         super().__init__()
         self.name = "WorkflowJobBase"
         self._dataset = dataset
@@ -16,12 +16,13 @@ class WorkflowJob(object):
         self._outname = None
         self._requires = {}
         self._parent = kwargs.get('parent')
+        self._parameters = params
+        self._job_workers = kwargs.get('job_workers', 8)
     
     def __str__(self):
         return f"{self.parent}:{self.name}:{self.dataset.dataset_id}"
 
     def __call__(self, slurm):
-
         print(f"starting up {str(self)}")
 
         if not self.meets_requirements():
@@ -38,23 +39,29 @@ class WorkflowJob(object):
         output_option = ('-o', f'{Path(self._slurm_out, self._outname).resolve()}')
         self._slurm_opts.extend([output_option])
 
-        tmp = NamedTemporaryFile(dir=self._scripts_path, delete=False)
+        script_name = f'{self._dataset.experiment}-{self.name}-{self._dataset.realm}-{self._dataset.grid}-{self._dataset.freq}'
+        tmp = NamedTemporaryFile(dir=self._slurm_out, delete=False, prefix=script_name)
+        messages_file = NamedTemporaryFile(dir=self._slurm_out, delete=False)
+        Path(messages_file.name).touch()
+        self._cmd = f"export MESSAGES_FILE={messages_file.name}\n" + self._cmd
 
         self.add_cmd_suffix(working_dir)
         slurm.render_script(self.cmd, tmp.name, self._slurm_opts)
-        self.dataset.update_status(f"{self._parent}{self.name}:Engaged:")
-        return slurm.sbatch(tmp.name)
+        job_id = slurm.sbatch(tmp.name)
+        self.dataset.update_status(f"{self._parent}:{self.name}:Engaged:slurm_id={job_id}")
+        return job_id
 
     
     def add_cmd_suffix(self, working_dir):
         suffix = f"""
 if [ $? -ne 0 ]
 then 
-    echo STAT:`date +%Y%m%d_%H%M%S`:{self.parent}:{self.name}:Fail: >> {self.dataset.status_path}
+    echo STAT:`date +%Y%m%d_%H%M%S`:WAREHOUSE:{self.parent}:{self.name}:Fail:`cat $MESSAGES_FILE` >> {self.dataset.status_path}
 else
-    echo STAT:`date +%Y%m%d_%H%M%S`:{self.parent}:{self.name}:Pass: >> {self.dataset.status_path}
+    echo STAT:`date +%Y%m%d_%H%M%S`:WAREHOUSE:{self.parent}:{self.name}:Pass:`cat $MESSAGES_FILE` >> {self.dataset.status_path}
 fi
 rm {Path(working_dir, ".lock")}
+rm $MESSAGES_FILE
 """
         self._cmd = self._cmd + suffix
 
@@ -137,3 +144,7 @@ rm {Path(working_dir, ".lock")}
     @property
     def parent(self):
         return self._parent
+    
+    @property
+    def params(self):
+        return self._parameters

--- a/warehouse/workflows/jobs/fixtimeunits.py
+++ b/warehouse/workflows/jobs/fixtimeunits.py
@@ -7,5 +7,8 @@ class FixTimeUnits(WorkflowJob):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.name = NAME
-        self._cmd = ''
-        self._requires = {'atmos-native-mon': None, 'ocean-native-mon': None}
+        self._requires = { '*-native-*': None }
+        self._cmd = f"""
+cd {self.scripts_path}
+python fix_time_units.py -p {self._job_workers} --time-units "{self.params["correct_units"]}" --time-offset {self.params["offset"]} {self.dataset.working_dir} {self.find_outpath()}
+"""

--- a/warehouse/workflows/postprocess/transitions.yaml
+++ b/warehouse/workflows/postprocess/transitions.yaml
@@ -48,7 +48,7 @@ GenerateLndTimeseries:Pass:
     - GenerateLndCmor:Ready
 GenerateLndTimeseries:Fail:
   default:
-    - Exit:exit_code
+    - Fail
 
 GenerateLndCmor:Ready:
   default:
@@ -58,7 +58,7 @@ GenerateLndCmor:Pass:
     - CMIPValidate:Ready
 GenerateLndCmor:Fail:
   default:
-    - Exit:exit_code
+    - Fail
 
 GenerateOcnCmor:Ready:
   default:
@@ -68,7 +68,7 @@ GenerateOcnCmor:Pass:
     - CMIPValidate:Ready
 GenerateOcnCmor:Fail:
   default:
-    - Exit:exit_code
+    - Fail
 
 GenerateIceCmor:Ready:
   default:
@@ -78,14 +78,14 @@ GenerateIceCmor:Pass:
     - CMIPValidate:Ready
 GenerateIceCmor:Fail:
   default:
-    - Exit:exit_code
+    - Fail
 
 CMIPValidate:Ready:
   default:
     - CMIPValidate:Engaged
 CMIPValidate:Pass:
   default:
-    - Exit:Success
+    - Pass
 CMIPValidate:Fail:
   default:
-    - Exit:exit_code
+    - Fail

--- a/warehouse/workflows/publication/transitions.yaml
+++ b/warehouse/workflows/publication/transitions.yaml
@@ -10,7 +10,7 @@ GenerateMapfile:Pass:
     - ValidateMapfile:Ready
 GenerateMapfile:Fail:
   default:
-    - Exit:exit_code
+    - Fail
 
 ValidateMapfile:Ready:
   default:
@@ -20,7 +20,7 @@ ValidateMapfile:Pass:
     - ValidateMapfile:Ready
 ValidateMapfile:Fail:
   default:
-    - Exit:exit_code
+    - Fail
 
 MoveToPublication:Ready:
   default:
@@ -30,7 +30,7 @@ MoveToPublication:Pass:
     - FixMapfilePaths:Ready
 MoveToPublication:Fail:
   default:
-    - Exit:exit_code
+    - Fail
 
 FixMapfilePaths:Ready:
   default:
@@ -40,7 +40,7 @@ FixMapfilePaths:Pass:
     - ESGFPublish:Ready
 FixMapfilePaths:Fail:
   default:
-    - Exit:exit_code
+    - Fail
 
 PublishESGF:Ready:
   default:
@@ -50,14 +50,14 @@ PublishESGF:Pass:
     - ValidateESGF:Ready
 PublishESGF:Fail:
   default:
-    - ValidateExit:exit_code
+    - ValidateFail
 
 Validate:Ready:
   default:
     - Validate:Engaged
 Validate:Pass:
   default:
-    - Exit:Success
+    - Pass
 Validate:Fail:
   default:
-    - Exit:exit_code
+    - Fail

--- a/warehouse/workflows/transitions.yaml
+++ b/warehouse/workflows/transitions.yaml
@@ -21,32 +21,32 @@ EXTRACTION:Pass:
         - Validation:Ready
 EXTRACTION:Fail:
     default:
-        - Exit:exit_code
+        - Exit:Fail
 
 VALIDATION:Pass:
     default:
         - PUBLICATION:Ready
 VALIDATION:Fail:
     default:
-        - exit_code
+        - Exit:Fail
 
 POSTPROCESS:Pass:
     default:
         - PUBLICATION:Ready
 POSTPROCESS:Fail:
     default:
-        - Exit:exit_code
+        - Exit:Fail
 
 PUBLICATION:Pass:
     default:
         - CLEANUP:Ready
 PUBLICATION:Fail:
     default:
-        - Exit:exit_code
+        - Exit:Fail
 
 CLEANUP:Pass:
     default:
-        - Exit:Success
+        - WAREHOUSE:Pass
 CLEANUP:Fail:
     default:
-        - Exit:exit_code
+        - Exit:Fail

--- a/warehouse/workflows/validation/atm-validation/transitions.yaml
+++ b/warehouse/workflows/validation/atm-validation/transitions.yaml
@@ -1,27 +1,14 @@
 ATMVALIDATION:Ready:
   default:
     - CheckTimeUnit:Ready
-    # - FixTimeUnits:Ready
-  # atmos-native-3hr:
-  #   - TimeUnitCheck:Ready
-  # atmos-native-3hr_snap:
-  #   - TimeUnitCheck:Ready
-  # atmos-native-6hr:
-  #   - TimeUnitCheck:Ready
-  # atmos-native-day:
-  #   - TimeUnitCheck:Ready
-  # atmos-native-mon:
-  #   - TimeUnitCheck:Ready
 
 CheckTimeUnit:Ready:
   default:
     - CheckTimeUnit:Engaged
 CheckTimeUnit:Pass:
   default:
-    - Exit:Success
-  
-
-TimeUnitCheck:Fail:
+    - TimeCheck:Ready
+CheckTimeUnit:Fail:
   default:
     - FixTimeUnits:Ready
 
@@ -30,26 +17,30 @@ FixTimeUnits:Ready:
     - FixTimeUnits:Engaged
 FixTimeUnits:Pass:
   default:
-    - TimeCheck:Ready
+    - Pass
 FixTimeUnits:Fail:
   default:
-    - Exit:exit_code
+    - Fail
 
 TimeCheck:Ready:
-    default:TimeCheck:Engaged
+    default:
+      - TimeCheck:Engaged
 TimeCheck:Pass:
-    default:CreateDerivedDataset:Ready
+    default:
+      - CreateDerivedDataset:Ready
 TimeCheck:Fail:
-    default:TimeRectify:Ready
+    default:
+      - TimeRectify:Ready
 
 TimeRectify:Ready:
-    TimeRectify:Engaged
+    default:
+      - TimeRectify:Engaged
 TimeRectify:Pass:
-    default:Success
-    atmos-native-mon:CreateDerivedDataset:Ready
-    lnd-nat-mon:CreateDerivedDataset:Ready
+    default:
+      - Pass
 TimeRectify:Fail:
-    Exit:exit_code
+    default:
+      - Fail
 
 
 

--- a/warehouse/workflows/validation/lnd-validation/transitions.yaml
+++ b/warehouse/workflows/validation/lnd-validation/transitions.yaml
@@ -4,31 +4,43 @@ LNDVALIDATION:Ready:
 
 
 TimeUnitCheck:Ready:
-    default:TimeUnitCheck:Engaged
+    default:
+        - TimeUnitCheck:Engaged
 TimeUnitCheck:Pass:
-    default:TimeCheck:Ready
+    default:
+        - TimeCheck:Ready
 TimeUnitCheck:Fail:
-    default:FixTimeUnit:Ready
+    default:
+        - FixTimeUnit:Ready
 
 FixTimeUnit:Ready:
-    default:FixTimeUnit:Engaged
+    default:
+        - FixTimeUnit:Engaged
 FixTimeUnit:Pass:
-    default:TimeCheck:Ready
+    default:
+        - TimeCheck:Ready
 FixTimeUnit:Fail:
-    default:Exit:exit_code
+    default:
+        - Fail
 
 TimeCheck:Ready:
-    default:TimeCheck:Engaged
+    default:
+        - TimeCheck:Engaged
 TimeCheck:Pass:
-    default:CreateDerivedDataset:Ready
+    default:
+        - CreateDerivedDataset:Ready
 TimeCheck:Fail:
-    default:TimeRectify:Ready
+    default:
+        - TimeRectify:Ready
 
 TimeRectify:Ready:
-    TimeRectify:Engaged
+    default:
+        - TimeRectify:Engaged
 TimeRectify:Pass:
-    default:Success
+    default:
+        - Pass
 TimeRectify:Fail:
-    Exit:exit_code
+    default:
+        - Fail
 
 

--- a/warehouse/workflows/validation/mpas-validation/transitions.yaml
+++ b/warehouse/workflows/validation/mpas-validation/transitions.yaml
@@ -5,9 +5,12 @@ MPASVALIDATION:Ready:
         - MPASTimeCheck:Ready
 
 MPASTimeCheck:Ready:
-    default:MPASTimeCheck:Engaged
+    default:
+        - MPASTimeCheck:Engaged
 MPASTimeCheck:Pass:
-    Exit:Success
+    default:
+        - Pass
 MPASTimeCheck:Fail:
-    Exit:exit_code
+    default:
+        - Fail
 

--- a/warehouse/workflows/validation/transitions.yaml
+++ b/warehouse/workflows/validation/transitions.yaml
@@ -18,21 +18,21 @@ VALIDATION:Ready:
 
 ATMVALIDATION:Pass:
     default:
-        - VALIDATION:Pass
+        - Pass
 ATMVALIDATION:Fail:
     default:
-        - Exit:exit_code
+        - Fail
 
 LNDVALIDATION:Pass:
     default:
         - VALIDATION:Pass
 LNDVALIDATION:Fail:
     default:
-        - Exit:exit_code
+        - VALIDATION:Fail
 
 MPASVALIDATION:Pass:
     default:
         - VALIDATION:Pass
 MPASVALIDATION:Fail:
     default:
-        - Exit:exit_code
+        - VALIDATION:Fail


### PR DESCRIPTION
This PR adds many things, including (but not limited to) the ability for datasets to transition between workflows on job success/failure, the ability for job to pass arbitrary parameters between them, and refactors the next_state method so that intermediate state values are written out.

Also adds implementations for two jobs, so they can be used as a sample for future development.