### PR TITLE
Add esgcet, zstash, and black to dev env

### DIFF
--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -18,12 +18,18 @@ dependencies:
   - termcolor=1.1.0
   - numpy=1.21.2
   - yaml=0.2.5
+  # QUALITY ASSURANCE
+  # ==================
   - watchdog=2.1.3
   - ipdb=0.13.9
-  # NOTE: This package is only published for Linux
-  - esgf-forge::autocurator=0.1
+  - black=21.9b0
   # CWL
   # ==================
   - cwltool=3.1.20210816212154
   - nodejs=16.6.1
+  # ADDITIONAL
+  # ==================
+  - esgf-forge::autocurator=0.1 # This package is only available for Linux
+  - esgf-forge::esgcet # Always get the latest version of esgcet
+  - e3sm::zstash=1.1.0
 prefix: /opt/miniconda3/envs/esgfpub_dev

--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -8,7 +8,7 @@ dependencies:
   # ==================
   - python=3.8.10
   - pip=21.2.4
-  - e3sm_to_cmip=1.7.3
+  - e3sm_to_cmip
   - nco=4.9.9
   - cmor=3.6.1
   - esgconfigparser=1.0.0a1
@@ -29,7 +29,7 @@ dependencies:
   - nodejs=16.6.1
   # ADDITIONAL
   # ==================
-  - esgf-forge::autocurator=0.1 # This package is only available for Linux
-  - esgf-forge::esgcet # Always get the latest version of esgcet
-  - e3sm::zstash=1.1.0
+  - esgf-forge::autocurator # This package is only available for Linux
+  - esgf-forge::esgcet
+  - e3sm::zstash
 prefix: /opt/miniconda3/envs/esgfpub_dev

--- a/docs/3_warehouse.md
+++ b/docs/3_warehouse.md
@@ -13,14 +13,6 @@ The warehouse utility allows for the automation of complex nested workflows with
       python setup.py install
       python setup.py clean
    ```
-
-3. Get the custom E3SM branch of the esgf publisher utility
-
-   ```bash
-   git clone https://github.com/sashakames/esg-publisher -b e3sm-custom
-   cd esg-publisher/pkg
-   python setup.py install
-   ```
   
 ## Usage
 


### PR DESCRIPTION
This PR adds `esgcet`, `zstash`, and `black` to the development environment `.yml`.

Since `esgcet` is included in the dev env `.yml`, developers no longer have to manually clone/pull and install the latest `master` repo of `esgcet`. Also, `esgcet` must be regularly released on Anaconda.

