### PR TITLE
Fix inadvertent removal of first file

### DIFF
--- a/datasm/scripts/rectify_time_index.py
+++ b/datasm/scripts/rectify_time_index.py
@@ -97,7 +97,8 @@ def collect_segments(inpath, num_jobs, timename, bndsname):
             b1, b2, idx = future.result()
             # if the first value is None, then the file failed its check
             # and the second value is the index of the file that failed
-            if not b1:
+            if b1 is None:
+                con_message("debug", f"Remove file {paths[idx]} for first value of time interval is none") 
                 # we can simply not add the entry to the file_info list
                 pass
             else:


### PR DESCRIPTION
The rectify_time_index.py scripts inadvertently remove first file of sub monthly output. It turned out to be a bug in the code after collecting file list after monotonic check. 
Zero and None both treated as same for if block `if not b1` , use `if b1 is None` so that zero is excluded. A message now will print out the file being removed.